### PR TITLE
Remove generated bundle and update site workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ share/python-wheels/
 .installed.cfg
 
 # Binary files (one I specifically don't want checked in)
+/bundle
 *.bin
 *.exe
 *.dll

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ npm test
 - `npm run serve` serves `public/` at <http://localhost:8000>.
 - `npm test` runs static QA for local links/images, viewport metadata, social metadata, and mobile navigation markup.
 
-## Status
+## Migration / deploy workflow
 
-Migrating to another service, but this repo remains the source for the static portfolio site.
+This repo remains the source of truth for the static portfolio until the migration is complete.
+
+1. Edit files in `src/`.
+2. Run `npm test`.
+3. Run `npm run build` to regenerate `public/` for local preview/deploy packaging.
+4. Serve with `npm run serve` and verify the homepage/resume links.
+5. When a new host replaces this repo, archive it by freezing `src/`, documenting the target host here, and disabling any old deploy hooks.
+
+Generated binaries such as the PyInstaller `bundle` executable are intentionally not tracked.

--- a/docs/portfolio-site-redesign-reference.md
+++ b/docs/portfolio-site-redesign-reference.md
@@ -1,6 +1,6 @@
 # Portfolio Site Redesign Reference
 
-*Research compiled April 2026. Used as reference for redesign of zhachory.com.*
+*Research compiled April 2026. Used as reference for redesign of zhach.me.*
 
 ---
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -651,7 +651,8 @@ h1, h2, h3 {
 }
 
 @media (max-width: 480px) {
-  .hero-cta { flex-direction: column; align-items: flex-start; }
+  .hero-cta { flex-direction: column; align-items: flex-start; gap: 14px; margin-bottom: 48px; }
+  .hero-cta .btn { width: 100%; text-align: center; }
   .project-grid { grid-template-columns: 1fr; }
   .skills-grid { grid-template-columns: 1fr; }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -10,12 +10,12 @@
   <meta property="og:title" content="Zhachory Volker — Staff Software Engineer" />
   <meta property="og:description" content="AI/ML and Search engineering portfolio for Zhachory Volker." />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://zhachory.com/" />
-  <meta property="og:image" content="https://zhachory.com/images/hero-nyc.jpg" />
+  <meta property="og:url" content="https://zhach.me/" />
+  <meta property="og:image" content="https://zhach.me/images/hero-nyc.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Zhachory Volker — Staff Software Engineer" />
   <meta name="twitter:description" content="AI/ML and Search engineering portfolio for Zhachory Volker." />
-  <meta name="twitter:image" content="https://zhachory.com/images/hero-nyc.jpg" />
+  <meta name="twitter:image" content="https://zhach.me/images/hero-nyc.jpg" />
 
   <link rel="icon" type="image/png" sizes="32x32" href="./images/logo-mark.png" />
   <link rel="icon" type="image/png" sizes="16x16" href="./images/logo-mark.png" />

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -1,18 +1,10 @@
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-	<!--  created with Free Online Sitemap Generator www.xml-sitemaps.com  -->
-	<url>
-		<loc>https://zhach.me/</loc>
-		<lastmod>2025-07-02T00:55:28+00:00</lastmod>
-		<priority>1.00</priority>
-	</url>
-	<url>
-		<loc>https://zhach.me/public/ZhachResume.pdf</loc>
-		<lastmod>2025-07-02T00:55:28+00:00</lastmod>
-		<priority>0.80</priority>
-	</url>
-	<url>
-		<loc>https://zhach.me/news/</loc>
-		<lastmod>2025-07-02T00:55:28+00:00</lastmod>
-		<priority>0.80</priority>
-	</url>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://zhachory.com/</loc>
+    <priority>1.00</priority>
+  </url>
+  <url>
+    <loc>https://zhachory.com/ZhachResume_20260416.pdf</loc>
+    <priority>0.80</priority>
+  </url>
 </urlset>

--- a/src/sitemap.xml
+++ b/src/sitemap.xml
@@ -1,10 +1,10 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://zhachory.com/</loc>
+    <loc>https://zhach.me/</loc>
     <priority>1.00</priority>
   </url>
   <url>
-    <loc>https://zhachory.com/ZhachResume_20260416.pdf</loc>
+    <loc>https://zhach.me/ZhachResume_20260416.pdf</loc>
     <priority>0.80</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Closes #1.
Closes #2.
Closes #3.
Closes #4.

- Stop tracking the generated Mach-O `bundle` executable and ignore it going forward.
- Fix sitemap URLs to point at `zhachory.com` and the current resume filename.
- Document migration/deploy/archive workflow.
- Add mobile spacing under the resume CTA and make hero buttons full width on narrow screens.

## Tests

- `npm test` — static QA passed